### PR TITLE
Bug h5link

### DIFF
--- a/R/CommonFG-DataSet.R
+++ b/R/CommonFG-DataSet.R
@@ -234,23 +234,16 @@ setMethod("list.datasets", signature(.Object="CommonFG"),
       path.full <- gsub("/+", "/", path.full)
     }
     
-    groups <- path.full
-    if(recursive) {
-      groups <- c(path.full, list.groups(.Object, path, TRUE, recursive = recursive))
-    }
-    
-    dsets <- lapply(groups, function(x) GetDataSetNames(.Object@pointer, x))
-    dsetlen <- sapply(dsets, length)
-    # Filter for groups which contain datasets
-    groups <- groups[dsetlen > 0]
-    dsets <- dsets[dsetlen > 0]
-    
+    dsets = GetDataSetNames(.Object@pointer, path.full, recursive)
     if(length(dsets) > 0) {
-      if(full.names) {
-        dsets <- lapply(1:length(groups), 
-                function(i) paste(groups[i], dsets[[i]], sep = "/"))
+      if(full.names)
+      {
+        dsets=paste(path.full, dsets, sep="/")
       }
-      dsets <- unlist(dsets)
+      else
+      {
+        dsets=gsub(".*/(.*)$", "\\1" , dsets)
+      }
       dsets <- gsub("/+", "/", dsets) # just to make sure...
     } else {
       dsets <- character(0)

--- a/R/CommonFG-Group.R
+++ b/R/CommonFG-Group.R
@@ -115,22 +115,22 @@ setMethod( "list.groups", signature(.Object="CommonFG"),
     if(inherits(.Object, "H5Group")) {
       path <- paste(path, .Object@location, sep = "/")
       path <- gsub("/+", "/", path)
-      }
- 
-      res <- character(0)
-      if(full.names) {
-        res <- paste(path, GetGroupNames(.Object@pointer, path, 
-                recursive = FALSE), sep = "/")
-      res <- unlist(gsub("/+", "/", res))
-      res <- sub("/+$", "", res)
-      res <- res[!res %in% c(path, "")]
-      if(recursive & length(res) > 0) {
-        res <- c(res, do.call(c, lapply(res, 
-                function(x) list.groups(.Object, x, full.names, recursive))))
-      }
-    } else {
-      res <- GetGroupNames(.Object@pointer, path, recursive)
     }
+ 
+    res <- character(0)
+    if(full.names) {
+      res <- paste(path, GetGroupNames(.Object@pointer, path, recursive), sep = "/")
+    }
+    else
+    {
+      res <- GetGroupNames(.Object@pointer, path, recursive)
+      res <- sub("/+$", "", res)
+      res <- gsub(".*/(.*)$", "\\1" , res)
+    }
+    res <- unlist(gsub("/+", "/", res))
+    res <- sub("/+$", "", res)
+    res <- res[!res %in% c(path, "")]
     res
-  })
+  }
+)
 

--- a/src/Group.h
+++ b/src/Group.h
@@ -9,9 +9,9 @@ Rcpp::XPtr<H5::Group> OpenGroup(Rcpp::XPtr<H5::CommonFG> file, std::string group
 bool CloseGroup(Rcpp::XPtr<H5::Group> group);
 bool ExistsGroup(Rcpp::XPtr<H5::CommonFG> file, std::string groupname);
 herr_t file_info(hid_t loc_id, const char *name, void *opdata);
-Rcpp::CharacterVector GetGroupNames(Rcpp::XPtr<H5::CommonFG> file, std::string path);
+Rcpp::CharacterVector GetGroupNames(Rcpp::XPtr<H5::CommonFG> file, std::string path, bool recursive);
 herr_t group_info(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data);
-Rcpp::CharacterVector GetDataSetNames(Rcpp::XPtr<H5::CommonFG> file, std::string path);
-herr_t dset_info(hid_t loc_id, const char *name, void *opdata);
+Rcpp::CharacterVector GetDataSetNames(Rcpp::XPtr<H5::CommonFG> file, std::string path, bool recursive);
+herr_t dset_info(hid_t loc_id, const char *name, const H5L_info_t *info, void *op_data);
 bool Unlink(Rcpp::XPtr<H5::CommonFG> file, std::string path);
 #endif // __File_h__

--- a/tests/testthat/test-DataSet.R
+++ b/tests/testthat/test-DataSet.R
@@ -135,22 +135,22 @@ test_that("DataSet-list-dataset",{
   group <- file["testgroupN"]
   h5close(group)
   
-  ex <- c("/testgroup/testset", "/testgroup/testgroup1/testset1", 
-      "/testgroup/testgroup2/testset2", "/testgroup3/testgroup3/testset3")
+  ex <- c("/testgroup/testgroup1/testset1", "/testgroup/testgroup2/testset2",
+          "/testgroup/testset", "/testgroup3/testgroup3/testset3")
   expect_that(list.datasets(file), is_identical_to(ex))
   
-  ex <- c("testset", "testset1", "testset2", "testset3")
+  ex <- c("testset1", "testset2", "testset", "testset3")
   expect_that(list.datasets(file, full.names = FALSE), is_identical_to(ex))
   
-  ex <- c("/testgroup/testset", "/testgroup/testgroup1/testset1", 
-      "/testgroup/testgroup2/testset2")
+  ex <- c("/testgroup/testgroup1/testset1", "/testgroup/testgroup2/testset2",
+          "/testgroup/testset")
   testgroup <- file["testgroup"]
   
   # TODO: Fix Bug implicit group extract/create
   #expect_that(list.datasets(file["testgroup"]), is_identical_to(ex))
   expect_that(list.datasets(testgroup), is_identical_to(ex))
      
-  ex <- c("testset", "testset1", "testset2")
+  ex <- c("testset1", "testset2", "testset")
   #expect_that(list.datasets(file["testgroup"], full.names = FALSE), is_identical_to(ex))
   expect_that(list.datasets(testgroup, full.names = FALSE), is_identical_to(ex))
   h5close(testgroup)

--- a/tests/testthat/test-H5Group.R
+++ b/tests/testthat/test-H5Group.R
@@ -113,8 +113,8 @@ test_that("CommonFG-list-groups",{
   group <- file["testgroupN"]
   h5close(group)
   
-  ex <- c("/testgroup", "/testgroup3", "/testgroupN", "/testgroup/testgroup1", 
-      "/testgroup/testgroup2", "/testgroup3/testgroup3")
+  ex <- c("/testgroup", "/testgroup/testgroup1", "/testgroup/testgroup2",
+ 	"/testgroup3", "/testgroup3/testgroup3", "/testgroupN")
   expect_that(list.groups(file), is_identical_to(ex))
   
   ex <- c("testgroup", "testgroup1", "testgroup2", "testgroup3", "testgroup3", "testgroupN")


### PR DESCRIPTION
I have created a patch for the support of H5Link. I had to adapt some of the tests because the traversal in depth-first order resulted in a different ordering of the same paths.