### PR TITLE
Add support for inspecting of HDF5's compound & time datatypes.

### DIFF
--- a/R/DataSet.R
+++ b/R/DataSet.R
@@ -104,6 +104,8 @@ setMethod("show", "DataSet",
                     x = "vlen-double",
                     y = "vlen-integer",
                     z = "vlen-logical",
+                    t = "compound",
+                    m = "datetime",
                     "unknown")
     maxdimstring <- ifelse(object@maxdim >= 1.844674e+19, "UNLIMITED", 
         sprintf("%.5g", object@maxdim))

--- a/src/Attribute.cpp
+++ b/src/Attribute.cpp
@@ -72,13 +72,12 @@ bool WriteAttribute(XPtr<Attribute> attribute, SEXP mat,
 SEXP ReadAttribute(XPtr<Attribute> attribute, NumericVector count) {
   try {
     DataType dtype = attribute->getDataType();
-    DTYPE tchar = GetTypechar(dtype);
 
     NumericVector count_rev = clone<NumericVector>(count);
     std::reverse(count_rev.begin(), count_rev.end());
 
-    SEXP data = AllocateRData(tchar, count);
-    data = ReadRDataAttribute(tchar, data, attribute);
+    SEXP data = AllocateRData(dtype, count);
+    data = ReadRDataAttribute(dtype, data, attribute);
     return data;
   } catch(Exception& error) {
     string msg = error.getDetailMsg() + " in " + error.getFuncName();

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -63,10 +63,9 @@ SEXP ReadDataset(XPtr<DataSet> dataset, XPtr<DataSpace> dataspace, NumericVector
     vector<hsize_t> count_t(count.begin(), count.end());
     Rcpp::XPtr<DataSpace> memspace(new DataSpace(count.length(), &count_t[0]));
     DataType dtype = dataset->getDataType();
-    DTYPE tchar = GetTypechar(dtype);
 
-    SEXP data = AllocateRData(tchar, count);
-	data = ReadRData(tchar, data, dataset, memspace, dataspace);
+    SEXP data = AllocateRData(dtype, count);
+	data = ReadRData(dtype, data, dataset, memspace, dataspace);
 	memspace->close();
 	return data;
   } catch(Exception& error) {

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -44,6 +44,10 @@ DataType GetDataType(const DTYPE datatype, int size = -1) {
       DataType type = GetDataType(T_VLEN_LOGICAL);
   	  return VarLenType(&type);
     }
+    case T_COMPOUND:
+      throw Rcpp::exception("Writing of compound datatypes is not yet supported.");
+    case T_DATETIME:
+      throw Rcpp::exception("Writing of date/time datatypes is not yet supported.");
     default: throw Rcpp::exception("Unknown data type.");
   }
 }
@@ -97,6 +101,11 @@ DTYPE GetTypechar(const DataType &dtype) {
 		 (dtype == VarLenType(&PredType::NATIVE_UINT16)) ) {
 	  return T_VLEN_INTEGER;
 	}
+    if (dtype.getClass() == H5T_COMPOUND) {
+        return T_COMPOUND;
+    } else if (dtype.getClass() == H5T_TIME) {
+        return T_DATETIME;
+    }
 
 	/*
 	if (dtype == GetDataType(T_VLEN_LOGICAL)) {
@@ -115,6 +124,8 @@ DTYPE GetTypechar(char typechar) {
 		case 'x': return T_VLEN_DOUBLE;
 		case 'y': return T_VLEN_INTEGER;
 		case 'z': return T_VLEN_LOGICAL;
+        case 't': return T_COMPOUND;
+        case 'm': return T_DATETIME;
 		default: throw new Exception("Typechar unknown");
 	}
 }
@@ -128,6 +139,8 @@ char GetTypechar(DTYPE typechar) {
 		case T_VLEN_DOUBLE: return 'x';
 		case T_VLEN_INTEGER: return 'y';
 		case T_VLEN_LOGICAL: return 'z';
+        case T_COMPOUND: return 't';
+        case T_DATETIME: return 'm';
 		default: throw new Exception("Typechar unknown");
 	}
 }
@@ -230,7 +243,8 @@ void *ConvertBuffer(const SEXP &mat, DTYPE datatype, int stsize) {
      }
 }
 
-SEXP AllocateRData(DTYPE tchar, NumericVector count) {
+SEXP AllocateRData(const DataType &dtype, NumericVector count) {
+    DTYPE tchar = GetTypechar(dtype);
 	int ndim = count.length();
 	SEXP data;
 
@@ -238,6 +252,10 @@ SEXP AllocateRData(DTYPE tchar, NumericVector count) {
 	std::reverse(count_rev.begin(), count_rev.end());
 
 	switch(tchar) {
+        case T_COMPOUND:
+          throw Rcpp::exception("Reading of compound datatypes is not yet supported.");
+        case T_DATETIME:
+          throw Rcpp::exception("Reading of date/time datatypes is not yet supported.");
 		case T_DOUBLE:
 			if (ndim == 1) {
 			data = PROTECT(Rf_allocVector(REALSXP, count[0]));
@@ -286,12 +304,17 @@ SEXP AllocateRData(DTYPE tchar, NumericVector count) {
 	return data; // Never reached
 }
 
-SEXP ReadRData(DTYPE tchar, SEXP data,
+SEXP ReadRData(const DataType &dtype, SEXP data,
 			XPtr<DataSet> dataset,
 			XPtr<DataSpace> memspace,
 			XPtr<DataSpace> dataspace ) {
 	try {
+        DTYPE tchar = GetTypechar(dtype);
 		switch(tchar) {
+            case T_COMPOUND:
+              throw Rcpp::exception("Reading of compound datatypes is not yet supported.");
+            case T_DATETIME:
+              throw Rcpp::exception("Reading of date/time datatypes is not yet supported.");
 			case T_DOUBLE:
 				dataset->read(REAL(data), PredType::NATIVE_DOUBLE, *memspace, *dataspace);
 				break;
@@ -390,10 +413,15 @@ SEXP ReadRData(DTYPE tchar, SEXP data,
   }
 }
 
-SEXP ReadRDataAttribute(DTYPE tchar, SEXP data,
+SEXP ReadRDataAttribute(const DataType &dtype, SEXP data,
 			XPtr<Attribute> attribute) {
 try {
+    DTYPE tchar = GetTypechar(dtype);
 	switch(tchar) {
+        case T_COMPOUND:
+          throw Rcpp::exception("Reading of compound datatypes is not yet supported.");
+        case T_DATETIME:
+          throw Rcpp::exception("Reading of date/time datatypes is not yet supported.");
 		case T_DOUBLE:
 			attribute->read(PredType::NATIVE_DOUBLE, REAL(data));
 			break;

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -4,7 +4,7 @@
 #ifndef __Helpers_h__
 #define __Helpers_h__
 enum DTYPE { T_DOUBLE, T_INTEGER, T_LOGICAL, T_CHARACTER, T_VLEN_FLOAT,
-	T_VLEN_DOUBLE, T_VLEN_INTEGER, T_VLEN_LOGICAL};
+	T_VLEN_DOUBLE, T_VLEN_INTEGER, T_VLEN_LOGICAL, T_COMPOUND, T_DATETIME};
 // Dataset functions
 H5::DataType GetDataType(const DTYPE datatype, int size);
 DTYPE GetTypechar(const H5::DataType &dtype);
@@ -12,14 +12,14 @@ DTYPE GetTypechar(char typechar);
 char GetTypechar(DTYPE typechar);
 void *ConvertBuffer(const SEXP &mat, DTYPE datatype, int stsize);
 H5S_seloper_t GetOperator(std::string opstring);
-SEXP AllocateRData(DTYPE tchar, Rcpp::NumericVector count);
+SEXP AllocateRData(const H5::DataType &dtype, Rcpp::NumericVector count);
 
-SEXP ReadRData(DTYPE tchar, SEXP data,
+SEXP ReadRData(const H5::DataType &dtype, SEXP data,
 			Rcpp::XPtr<H5::DataSet> dataset,
 			Rcpp::XPtr<H5::DataSpace> memspace,
 			Rcpp::XPtr<H5::DataSpace> dataspace);
 
-SEXP ReadRDataAttribute(DTYPE tchar, SEXP data,
+SEXP ReadRDataAttribute(const H5::DataType &dtype, SEXP data,
 		Rcpp::XPtr<H5::Attribute> attribute);
 
 #endif // __Dataset_h__


### PR DESCRIPTION
Note that this does NOT add reading or writing support. The idea is to make it possible to view compound/time datasts in `h5` even though it cannot currently read them. This PR will allow the creation of DataSet objects for datasets with these types, but they cannot be read into R itself.

This commit contains a change to the API in `src/Helpers.h` -- alloc and read functions now need full `H5::DataType` information. This is not _strictly_ necessary for this feature, but it probably will be when full support for e.g. compound datatypes is added.

Happy to make changes to this PR as requested!

