### PR TITLE
Update OS X install command

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,7 +23,7 @@ library including its C++ API and header files.
 2. MACOSX
 	Using MacOSX and Homebrew (http://brew.sh) the following command can be used 
 	to install the HDF5 library dependencies and headers:
-	$ brew install homebrew/science/hdf5 --enable-cxx
+	$ brew install hdf5
 
 3. WINDOWS
 	The h5 package already ships with the compiled version of the HDF library 

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,7 @@ This package already ships the library for windows operating systems through [h5
 ### OS X
 Using OS X and [Homebrew](http://brew.sh) you can use the following command to install HDF5 library dependencies and headers:
 ```shell
-brew install homebrew/science/hdf5 --enable-cxx
+brew install hdf5
 ```
 
 ### Linux (e.g. Debian, Ubuntu)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This package already ships the library for windows operating systems through [h5
 ### OS X
 Using OS X and [Homebrew](http://brew.sh) you can use the following command to install HDF5 library dependencies and headers:
 ```shell
-brew install homebrew/science/hdf5 --enable-cxx
+brew install hdf5
 ```
 
 ### Linux (e.g. Debian, Ubuntu)

--- a/configure
+++ b/configure
@@ -1717,7 +1717,7 @@ if test -z "${H5CPP}"; then
   	The required HDF5 library files can be installed as follows:
   	    - Debian-based (e.g. Debian >= 8.0, Ubuntu >= 15.04): 'sudo apt-get install libhdf5-dev'
         - Old Debian-based (e.g Debian < 8.0, Ubuntu < 15.04): Install from source (see INSTALL)
-        - OS X using Homebrew: 'brew install homebrew/science/hdf5 --enable-cxx'
+        - OS X using Homebrew: 'brew install hdf5'
         - RPM-based (e.g Fedora): 'sudo yum install hdf5-devel'" "$LINENO" 5
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ if test -z "${H5CPP}"; then
   	The required HDF5 library files can be installed as follows:
   	    - Debian-based (e.g. Debian >= 8.0, Ubuntu >= 15.04): 'sudo apt-get install libhdf5-dev'
         - Old Debian-based (e.g Debian < 8.0, Ubuntu < 15.04): Install from source (see INSTALL)
-        - OS X using Homebrew: 'brew install homebrew/science/hdf5 --enable-cxx'
+        - OS X using Homebrew: 'brew install hdf5'
         - RPM-based (e.g Fedora): 'sudo yum install hdf5-devel'])
 fi
 

--- a/travis_setup.sh
+++ b/travis_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then # use homebrew version
-  brew install homebrew/science/hdf5
+  brew install hdf5
 else # install from source
   cd ..
   if [ "$HDF5_VERSION" == "1.10.1" ]; then


### PR DESCRIPTION
Fix deprecated warning:

```
$ brew install homebrew/science/hdf5 --enable-cxx
==> Installing hdf5 from homebrew/science
Warning: homebrew/science/hdf5: --enable-cxx was deprecated; using --with-cxx instead!
Warning: homebrew/science/hdf5: this formula has no --with-cxx option so it will be ignored!
==> Downloading https://homebrew.bintray.com/bottles-science/hdf5-1.10.1.sierra.bottle.tar.gz
==> Pouring hdf5-1.10.1.sierra.bottle.tar.gz
🍺  /usr/local/Cellar/hdf5/1.10.1: 203 files, 12.9MB
```